### PR TITLE
Translating sibling nodes with Google Translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@
 **[lazy.nvim](https://github.com/folke/lazy.nvim)**
 
 ```lua
-{ "olrtg/nvim-i18n", dependencies = "MunifTanjim/nui.nvim", config = true },
+{
+  "olrtg/nvim-i18n",
+  dependencies = { "MunifTanjim/nui.nvim", "nvim-lua/plenary.nvim" },
+  config = true,
+},
 ```
 
 # Usage
 
 ```
-:I18n
+:Internationalization
 ```
 
 You can navigate with `h`/`j`/`k`/`l`, `H` for closing all nodes, `L` for opening all nodes, `Enter` for opening nodes or editing translations.

--- a/lua/nvim-i18n/detector.lua
+++ b/lua/nvim-i18n/detector.lua
@@ -41,7 +41,11 @@ function M.detector()
 	if M.is_web_project() then
 		for _, framework in pairs(frameworks.web) do
 			for _, package in pairs(framework.detection.package_json) do
-				-- NOTE: This in theory will just return in the first match but this is not correct
+				-- NOTE: This in theory will just return in the first match but
+				-- this is not correct.
+				-- EDIT: Idk about this, maybe I wanted to
+				-- match all of the dependencies before confirming that uses X
+				-- framework.
 				if M.is_dependency_in_package_json(package) then
 					return framework
 				end

--- a/lua/nvim-i18n/init.lua
+++ b/lua/nvim-i18n/init.lua
@@ -11,6 +11,11 @@ function M.open()
 		return
 	end
 
+	if vim.fn.bufexists(0) == 0 then
+		vim.notify("You cannot run this command in an empty buffer", vim.log.levels.ERROR)
+		return
+	end
+
 	local captures = {}
 
 	for _, query_string in pairs(detected.query_strings) do
@@ -39,7 +44,7 @@ function M.open()
 end
 
 function M.setup()
-	vim.api.nvim_create_user_command("I18n", M.open, {})
+	vim.api.nvim_create_user_command("Internationalization", M.open, {})
 end
 
 return M

--- a/lua/nvim-i18n/ui.lua
+++ b/lua/nvim-i18n/ui.lua
@@ -97,6 +97,32 @@ function M.create_tree(split, nodes)
 		end
 	end)
 
+	-- translate all keys with google translate
+	split:map("n", "T", function()
+		local node = tree:get_node()
+
+		if not node:has_children() then
+			local locale = node.text:match("^[^:]+")
+			local node_without_locale = node.text:gsub("^[^:]+: ", "")
+			local text = u.encode_url(node_without_locale)
+
+			local response = vim.json.decode(
+				require("plenary.curl").get(
+					"https://translate.googleapis.com/translate_a/single?client=gtx&sl="
+						.. locale
+						.. "&tl="
+						.. "es"
+						.. "&hl=zh-CN&dt=t&dt=bd&ie=UTF-8&oe=UTF-8&dj=1&source=icon&q="
+						.. text
+				).body
+			)
+
+			vim.print(response.sentences)
+		end
+
+		tree:render()
+	end)
+
 	tree:render()
 end
 
@@ -139,5 +165,7 @@ function M.prompt_new_translation(node)
 
 	return translation
 end
+
+function M.translate_with_service() end
 
 return M

--- a/lua/nvim-i18n/utils.lua
+++ b/lua/nvim-i18n/utils.lua
@@ -44,15 +44,36 @@ function M.char_to_hex(char)
 end
 
 --- @param url string
---- @return string|nil
+--- @return string
 function M.encode_url(url)
-	if url == nil then
-		return
-	end
 	url = url:gsub("\n", "\r\n")
 	url = url:gsub("([^%w _%%%-%.~])", M.char_to_hex)
 	url = url:gsub(" ", "+")
 	return url
+end
+
+---@class Payload
+---@field text string
+---@field from string
+---@field to string
+---
+---@param payload Payload
+---@return unknown
+function M.get_translation_from_google_translate(payload)
+	local encoded_text = M.encode_url(payload.text)
+
+	local response = vim.json.decode(
+		require("plenary.curl").get(
+			"https://translate.googleapis.com/translate_a/single?client=gtx&sl="
+				.. payload.from
+				.. "&tl="
+				.. payload.to
+				.. "&hl=zh-CN&dt=t&dt=bd&ie=UTF-8&oe=UTF-8&dj=1&source=icon&q="
+				.. encoded_text
+		).body
+	)
+
+	return response.sentences[1].trans
 end
 
 return M

--- a/lua/nvim-i18n/utils.lua
+++ b/lua/nvim-i18n/utils.lua
@@ -37,4 +37,22 @@ function M.get_ts_query_by_keys(keys)
 	return query
 end
 
+--- @param char string|number
+--- @return string
+function M.char_to_hex(char)
+	return string.format("%%%02X", string.byte(char))
+end
+
+--- @param url string
+--- @return string|nil
+function M.encode_url(url)
+	if url == nil then
+		return
+	end
+	url = url:gsub("\n", "\r\n")
+	url = url:gsub("([^%w _%%%-%.~])", M.char_to_hex)
+	url = url:gsub(" ", "+")
+	return url
+end
+
 return M


### PR DESCRIPTION
This is a basic implementation of the `T` keybinding, which translates all sibling nodes using a node as the base. So for example when you're building a new feature you may have only the English localization of a message and then want to use that as the base for translating to all the other languages.